### PR TITLE
:sparkles: Adds TypeScript support for game scripts

### DIFF
--- a/app/data/i18n/Brazilian Portuguese.json
+++ b/app/data/i18n/Brazilian Portuguese.json
@@ -46,6 +46,7 @@
         "nothingToShowFiller": "",
         "required": "",
         "settings": "",
+        "typescript": "",
         "fieldTypes": {
             "checkbox": "",
             "code": "",

--- a/app/data/i18n/Chinese Simplified.json
+++ b/app/data/i18n/Chinese Simplified.json
@@ -46,6 +46,7 @@
         "nothingToShowFiller": "这里没有什么可以展示的",
         "required": "必需",
         "settings": "设置",
+        "typescript": "",
         "fieldTypes": {
             "checkbox": "复选",
             "code": "程序代码",

--- a/app/data/i18n/Comments.json
+++ b/app/data/i18n/Comments.json
@@ -46,6 +46,7 @@
         "nothingToShowFiller": "",
         "required": "",
         "settings": "",
+        "typescript": "",
         "fieldTypes": {
             "checkbox": "",
             "code": "",

--- a/app/data/i18n/Debug.json
+++ b/app/data/i18n/Debug.json
@@ -46,6 +46,7 @@
         "nothingToShowFiller": "common.nothingToShowFiller",
         "required": "common.required",
         "settings": "common.settings",
+        "typescript": "common.typescript",
         "fieldTypes": {
             "checkbox": "common.fieldTypes.checkbox",
             "code": "common.fieldTypes.code",

--- a/app/data/i18n/Dutch.json
+++ b/app/data/i18n/Dutch.json
@@ -46,6 +46,7 @@
         "nothingToShowFiller": "Hier is niets te zien!",
         "required": "Vereist",
         "settings": "Instellingen",
+        "typescript": "",
         "fieldTypes": {
             "checkbox": "Selectievakje",
             "code": "Codebox",

--- a/app/data/i18n/English.json
+++ b/app/data/i18n/English.json
@@ -52,6 +52,7 @@
         "zoomOut": "Zoom out",
         "undo": "Undo",
         "redo": "Redo",
+        "typescript": "Allow TypeScript",
         "fieldTypes": {
             "checkbox": "Checkbox",
             "code": "Codebox",

--- a/app/data/i18n/French.json
+++ b/app/data/i18n/French.json
@@ -72,6 +72,7 @@
         "nothingToShowFiller": "",
         "required": "",
         "settings": "",
+        "typescript": "",
         "fieldTypes": {
             "checkbox": "",
             "code": "",

--- a/app/data/i18n/German.json
+++ b/app/data/i18n/German.json
@@ -46,6 +46,7 @@
         "nothingToShowFiller": "",
         "required": "",
         "settings": "",
+        "typescript": "",
         "fieldTypes": {
             "checkbox": "",
             "code": "",

--- a/app/data/i18n/Japanese.json
+++ b/app/data/i18n/Japanese.json
@@ -48,6 +48,7 @@
         "zoom": "拡大",
         "zoomIn": "ズームイン",
         "zoomOut": "ズームアウト",
+        "typescript": "",
         "fieldTypes": {
             "checkbox": "チェックボックス",
             "code": "コード",

--- a/app/data/i18n/Polish.json
+++ b/app/data/i18n/Polish.json
@@ -46,6 +46,7 @@
         "nothingToShowFiller": "",
         "required": "",
         "settings": "",
+        "typescript": "",
         "fieldTypes": {
             "checkbox": "",
             "code": "",

--- a/app/data/i18n/Romanian.json
+++ b/app/data/i18n/Romanian.json
@@ -46,6 +46,7 @@
         "nothingToShowFiller": "",
         "required": "",
         "settings": "",
+        "typescript": "",
         "fieldTypes": {
             "checkbox": "",
             "code": "",

--- a/app/data/i18n/Russian.json
+++ b/app/data/i18n/Russian.json
@@ -46,6 +46,7 @@
         "nothingToShowFiller": "Нечего показывать!",
         "required": "Требуется",
         "settings": "Настройки",
+        "typescript": "",
         "fieldTypes": {
             "checkbox": "Чекбокс",
             "code": "Поле с кодом",

--- a/app/data/i18n/Spanish.json
+++ b/app/data/i18n/Spanish.json
@@ -46,6 +46,7 @@
         "nothingToShowFiller": "",
         "required": "",
         "settings": "",
+        "typescript": "",
         "fieldTypes": {
             "checkbox": "",
             "code": "",
@@ -948,6 +949,7 @@
         "eventAlreadyExists": "",
         "localEventVars": "",
         "createEventHint": "",
+        "typescript": "",
         "coreEventsCategories": {
             "lifecycle": "",
             "actions": "",

--- a/app/data/i18n/Ukranian.json
+++ b/app/data/i18n/Ukranian.json
@@ -46,6 +46,7 @@
         "nothingToShowFiller": "Нема чого показувати!",
         "required": "Потрібно",
         "settings": "Налаштування",
+        "typescript": "",
         "fieldTypes": {
             "checkbox": "Чекбокс",
             "code": "Поле з кодом",

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ctjs",
-  "version": "2.2.0",
+  "version": "3.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ctjs",
-      "version": "2.2.0",
+      "version": "3.0.0",
       "license": "MIT",
       "dependencies": {
         "@capacitor/cli": "^3.4.0",
@@ -40,6 +40,7 @@
         "pixi.js-legacy": "5.3.11",
         "png2icons": "^2.0.1",
         "serve-handler": "^6.1.3",
+        "sucrase": "^3.25.0",
         "terser": "^5.14.2",
         "ttf2woff": "^2.0.2"
       }
@@ -1283,6 +1284,11 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/any-promise": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+      "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A=="
     },
     "node_modules/anymatch": {
       "version": "3.1.2",
@@ -5317,6 +5323,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/mz": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
+      "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+      "dependencies": {
+        "any-promise": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "thenify-all": "^1.0.0"
+      }
+    },
     "node_modules/nanoid": {
       "version": "3.1.31",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.31.tgz",
@@ -8096,6 +8112,14 @@
         "node": ">=4"
       }
     },
+    "node_modules/pirates": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.5.tgz",
+      "integrity": "sha512-8V9+HQPupnaXMA23c5hvl69zXvTwTzyAYasnkb0Tts4XvO4CliqONMOnvlq26rkhLC3nWDFBJf73LU1e1VZLaQ==",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/pixi-ease": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/pixi-ease/-/pixi-ease-3.0.7.tgz",
@@ -9318,6 +9342,34 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/sucrase": {
+      "version": "3.25.0",
+      "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.25.0.tgz",
+      "integrity": "sha512-WxTtwEYXSmZArPGStGBicyRsg5TBEFhT5b7N+tF+zauImP0Acy+CoUK0/byJ8JNPK/5lbpWIVuFagI4+0l85QQ==",
+      "dependencies": {
+        "commander": "^4.0.0",
+        "glob": "7.1.6",
+        "lines-and-columns": "^1.1.6",
+        "mz": "^2.7.0",
+        "pirates": "^4.0.1",
+        "ts-interface-checker": "^0.1.9"
+      },
+      "bin": {
+        "sucrase": "bin/sucrase",
+        "sucrase-node": "bin/sucrase-node"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/sucrase/node_modules/commander": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+      "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/sumchecker": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/sumchecker/-/sumchecker-3.0.1.tgz",
@@ -9462,6 +9514,25 @@
         "node": ">=0.10"
       }
     },
+    "node_modules/thenify": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
+      "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
+      "dependencies": {
+        "any-promise": "^1.0.0"
+      }
+    },
+    "node_modules/thenify-all": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
+      "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
+      "dependencies": {
+        "thenify": ">= 3.1.0 < 4"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/through": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
@@ -9573,6 +9644,11 @@
       "dependencies": {
         "utf8-byte-length": "^1.0.1"
       }
+    },
+    "node_modules/ts-interface-checker": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
+      "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA=="
     },
     "node_modules/ts-node": {
       "version": "10.4.0",
@@ -11354,6 +11430,11 @@
       "requires": {
         "color-convert": "^1.9.0"
       }
+    },
+    "any-promise": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+      "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A=="
     },
     "anymatch": {
       "version": "3.1.2",
@@ -14402,6 +14483,16 @@
         "minimatch": "^3.0.4"
       }
     },
+    "mz": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
+      "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+      "requires": {
+        "any-promise": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "thenify-all": "^1.0.0"
+      }
+    },
     "nanoid": {
       "version": "3.1.31",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.31.tgz",
@@ -16292,6 +16383,11 @@
       "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
       "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
     },
+    "pirates": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.5.tgz",
+      "integrity": "sha512-8V9+HQPupnaXMA23c5hvl69zXvTwTzyAYasnkb0Tts4XvO4CliqONMOnvlq26rkhLC3nWDFBJf73LU1e1VZLaQ=="
+    },
     "pixi-ease": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/pixi-ease/-/pixi-ease-3.0.7.tgz",
@@ -17235,6 +17331,26 @@
         "escape-string-regexp": "^1.0.2"
       }
     },
+    "sucrase": {
+      "version": "3.25.0",
+      "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.25.0.tgz",
+      "integrity": "sha512-WxTtwEYXSmZArPGStGBicyRsg5TBEFhT5b7N+tF+zauImP0Acy+CoUK0/byJ8JNPK/5lbpWIVuFagI4+0l85QQ==",
+      "requires": {
+        "commander": "^4.0.0",
+        "glob": "7.1.6",
+        "lines-and-columns": "^1.1.6",
+        "mz": "^2.7.0",
+        "pirates": "^4.0.1",
+        "ts-interface-checker": "^0.1.9"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+          "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA=="
+        }
+      }
+    },
     "sumchecker": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/sumchecker/-/sumchecker-3.0.1.tgz",
@@ -17340,6 +17456,22 @@
       "resolved": "https://registry.npmjs.org/text-extensions/-/text-extensions-1.9.0.tgz",
       "integrity": "sha512-wiBrwC1EhBelW12Zy26JeOUkQ5mRu+5o8rpsJk5+2t+Y5vE7e842qtZDQ2g1NpX/29HdyFeJ4nSIhI47ENSxlQ=="
     },
+    "thenify": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
+      "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
+      "requires": {
+        "any-promise": "^1.0.0"
+      }
+    },
+    "thenify-all": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
+      "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
+      "requires": {
+        "thenify": ">= 3.1.0 < 4"
+      }
+    },
     "through": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
@@ -17429,6 +17561,11 @@
       "requires": {
         "utf8-byte-length": "^1.0.1"
       }
+    },
+    "ts-interface-checker": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
+      "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA=="
     },
     "ts-node": {
       "version": "10.4.0",

--- a/app/package.json
+++ b/app/package.json
@@ -84,6 +84,7 @@
     "pixi.js-legacy": "5.3.11",
     "png2icons": "^2.0.1",
     "serve-handler": "^6.1.3",
+    "sucrase": "^3.25.0",
     "terser": "^5.14.2",
     "ttf2woff": "^2.0.2"
   }

--- a/src/node_requires/exporter/index.ts
+++ b/src/node_requires/exporter/index.ts
@@ -373,7 +373,13 @@ const exportCtProject = async (
 
     /* User-defined scripts */
     for (const script of project.scripts) {
-        buffer += script.code + ';\n';
+        if (script.typescript) {
+            const transform = require("sucrase").transform;
+            buffer += transform(script.code, {transforms: ["typescript" ]}).code + ';\n';
+        }
+        else {
+            buffer += script.code + ';\n';
+        }
     }
 
     /* passthrough copy of files in the `include` folder */

--- a/src/riotTags/project-settings/tabs/script-editor.tag
+++ b/src/riotTags/project-settings/tabs/script-editor.tag
@@ -1,6 +1,12 @@
 script-editor.aView
     .flexfix.tall
         div.flexfix-header
+            label.toright.checkbox
+                input(
+                    type="checkbox" checked="{script.typescript}"
+                    onchange="{toggleTypescript}"
+                )
+                b {voc.typescript}
             b {voc.name}
             input(type="text" value="{script.name}" onchange="{updateScriptName}")
         .flexfix-body
@@ -42,6 +48,10 @@ script-editor.aView
             // Manually destroy the editor to free up the memory
             this.editor.dispose();
         });
+
+        this.toggleTypescript = () => {
+            this.script.typescript = !this.script.typescript;
+        };
 
         this.saveScript = () => {
             const glob = require('./data/node_requires/glob');


### PR DESCRIPTION
This pull request supports TypeScript in a game's *custom scripts only* using [sucrase](https://github.com/alangpierce/sucrase) on an opt-in per-script basis.

The work however was so successful that I decided instead to support TypeScript everywhere by default.